### PR TITLE
Added automatic protobuf compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# PyCharm
+.idea/

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ pip install -r requirements.txt
 Then you must compile the Protobuf libraries:
 
 ```bash
-protoc object_detection/protos/*.proto --python_out=.
+python protoc_compiller.py
 ```
 
 Add `models` and `models/slim` to your `PYTHONPATH`:

--- a/protoc_compiller.py
+++ b/protoc_compiller.py
@@ -1,0 +1,15 @@
+import subprocess
+from os import listdir
+
+protobuf_dir = './object_detection/protos'
+protobuf_path_list = [f for f in listdir(protobuf_dir) if f.endswith('.proto')]
+
+for path in protobuf_path_list:
+    try:
+        subprocess.Popen('protoc {0}/{1} --python_out=.'.format(protobuf_dir, path))
+    except Exception as e:
+        print('Error: \'protoc\' is not recognized as an internal or external command, operable program or batch file.')
+        print('Download and install \'protoc\' for your platform: https://github.com/protocolbuffers/protobuf/releases')
+        exit(0)
+
+print('successfully!')


### PR DESCRIPTION
If i write `protoc object_detection/protos/*.proto --python_out=.` in `Windows 10` then get the next error:

`object_detection/protos/*.proto: No such file or directory`

Relying on my experience and on issue #33, I wrote a script that automatically compiles protobuf libs
